### PR TITLE
refactor: align analysis and assaydevelopment modules with nf-core layout

### DIFF
--- a/modules/local/cellprofiler/analysis/environment.yml
+++ b/modules/local/cellprofiler/analysis/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::cellprofiler=4.2.8"

--- a/modules/local/cellprofiler/analysis/main.nf
+++ b/modules/local/cellprofiler/analysis/main.nf
@@ -1,18 +1,19 @@
-process CELLPROFILER_ASSAYDEVELOPMENT {
+process CELLPROFILER_ANALYSIS {
     tag "${meta.id}"
     label 'process_medium'
 
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/cellprofiler:4.2.8--pyhdfd78af_0'
         : 'community.wave.seqera.io/library/cellprofiler:4.2.8--aff0a99749304a7f'}"
 
     input:
     tuple val(meta), val(images_meta), path(images, stageAs: "images/*"), path(illum_files, stageAs: "images/*")
-    path assay_development_cppipe
+    path analysis_cppipe
 
     output:
-    tuple val(meta), path("assaydevelopment/*.png"), emit: png
-    tuple val(meta), path("assaydevelopment/Image.csv"), emit: csv, optional: true
+    tuple val(meta), path("analysis"), emit: output_dir
+    tuple val(meta), path("analysis/*.png"), emit: pngs, optional: true
     path "versions.yml", emit: versions
 
     when:
@@ -27,15 +28,15 @@ process CELLPROFILER_ASSAYDEVELOPMENT {
     echo '${metadata_json}' > metadata.json
     generate_illumination_apply_csv.py --metadata metadata.json --images-dir ./images --output load_data.csv
 
-    mkdir -p assaydevelopment
+    mkdir -p analysis
 
     cellprofiler -c -r \
     ${args} \
-    -p ${assay_development_cppipe} \
-    -o assaydevelopment \
+    -p ${analysis_cppipe} \
+    -o analysis \
     --data-file=load_data.csv \
     --image-directory ./images/ \
-    -g Metadata_Plate=${meta.plate},Metadata_Well=${meta.well}
+    -g Metadata_Plate=${meta.plate},Metadata_Well=${meta.well},Metadata_Site=${meta.site}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -45,9 +46,12 @@ process CELLPROFILER_ASSAYDEVELOPMENT {
 
     stub:
     """
-    mkdir -p assaydevelopment
-    echo 'stub' > assaydevelopment/mock_segmentedimage.png
-    echo 'ImageNumber,Metadata_Plate' > assaydevelopment/Image.csv
+    mkdir -p analysis
+    echo 'ImageNumber,Metadata_Plate' > analysis/Image.csv
+    echo 'ImageNumber,ObjectNumber' > analysis/Nuclei.csv
+    echo 'ImageNumber,ObjectNumber' > analysis/Cells.csv
+    echo 'ImageNumber,ObjectNumber' > analysis/Cytoplasm.csv
+    touch analysis/mock_overlay.png
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/cellprofiler/analysis/tests/main.nf.test
+++ b/modules/local/cellprofiler/analysis/tests/main.nf.test
@@ -1,6 +1,6 @@
 nextflow_process {
     name "Test Process CELLPROFILER_ANALYSIS"
-    script "../../analysis.nf"
+    script "../main.nf"
     process "CELLPROFILER_ANALYSIS"
     tag "cellprofiler"
     tag "cellprofiler/analysis"

--- a/modules/local/cellprofiler/assaydevelopment/environment.yml
+++ b/modules/local/cellprofiler/assaydevelopment/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::cellprofiler=4.2.8"

--- a/modules/local/cellprofiler/assaydevelopment/main.nf
+++ b/modules/local/cellprofiler/assaydevelopment/main.nf
@@ -1,18 +1,19 @@
-process CELLPROFILER_ANALYSIS {
+process CELLPROFILER_ASSAYDEVELOPMENT {
     tag "${meta.id}"
     label 'process_medium'
 
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/cellprofiler:4.2.8--pyhdfd78af_0'
         : 'community.wave.seqera.io/library/cellprofiler:4.2.8--aff0a99749304a7f'}"
 
     input:
     tuple val(meta), val(images_meta), path(images, stageAs: "images/*"), path(illum_files, stageAs: "images/*")
-    path analysis_cppipe
+    path assay_development_cppipe
 
     output:
-    tuple val(meta), path("analysis"), emit: output_dir
-    tuple val(meta), path("analysis/*.png"), emit: pngs, optional: true
+    tuple val(meta), path("assaydevelopment/*.png"), emit: png
+    tuple val(meta), path("assaydevelopment/Image.csv"), emit: csv, optional: true
     path "versions.yml", emit: versions
 
     when:
@@ -27,15 +28,15 @@ process CELLPROFILER_ANALYSIS {
     echo '${metadata_json}' > metadata.json
     generate_illumination_apply_csv.py --metadata metadata.json --images-dir ./images --output load_data.csv
 
-    mkdir -p analysis
+    mkdir -p assaydevelopment
 
     cellprofiler -c -r \
     ${args} \
-    -p ${analysis_cppipe} \
-    -o analysis \
+    -p ${assay_development_cppipe} \
+    -o assaydevelopment \
     --data-file=load_data.csv \
     --image-directory ./images/ \
-    -g Metadata_Plate=${meta.plate},Metadata_Well=${meta.well},Metadata_Site=${meta.site}
+    -g Metadata_Plate=${meta.plate},Metadata_Well=${meta.well}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -45,12 +46,9 @@ process CELLPROFILER_ANALYSIS {
 
     stub:
     """
-    mkdir -p analysis
-    echo 'ImageNumber,Metadata_Plate' > analysis/Image.csv
-    echo 'ImageNumber,ObjectNumber' > analysis/Nuclei.csv
-    echo 'ImageNumber,ObjectNumber' > analysis/Cells.csv
-    echo 'ImageNumber,ObjectNumber' > analysis/Cytoplasm.csv
-    touch analysis/mock_overlay.png
+    mkdir -p assaydevelopment
+    echo 'stub' > assaydevelopment/mock_segmentedimage.png
+    echo 'ImageNumber,Metadata_Plate' > assaydevelopment/Image.csv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test
+++ b/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test
@@ -1,6 +1,6 @@
 nextflow_process {
     name "Test Process CELLPROFILER_ASSAYDEVELOPMENT"
-    script "../../assaydevelopment.nf"
+    script "../main.nf"
     process "CELLPROFILER_ASSAYDEVELOPMENT"
     tag "cellprofiler"
     tag "cellprofiler/assaydevelopment"

--- a/workflows/cellpainting.nf
+++ b/workflows/cellpainting.nf
@@ -6,8 +6,8 @@
 include { MULTIQC                } from '../modules/nf-core/multiqc/main'
 include { CYTOTABLE              } from '../modules/local/cytotable'
 include { CELLPROFILER_ILLUMINATIONCORRECTION } from '../modules/local/cellprofiler/illuminationcorrection'
-include { CELLPROFILER_ANALYSIS } from '../modules/local/cellprofiler/analysis.nf'
-include { CELLPROFILER_ASSAYDEVELOPMENT } from '../modules/local/cellprofiler/assaydevelopment.nf'
+include { CELLPROFILER_ANALYSIS } from '../modules/local/cellprofiler/analysis'
+include { CELLPROFILER_ASSAYDEVELOPMENT } from '../modules/local/cellprofiler/assaydevelopment'
 
 include { paramsSummaryMap       } from 'plugin/nf-schema'
 include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'


### PR DESCRIPTION
## Summary
- Move `analysis.nf` and `assaydevelopment.nf` into their subdirectories as `main.nf`, matching the nf-core module layout already used by `illuminationcorrection`
- Add `environment.yml` and a `conda "${moduleDir}/environment.yml"` directive to both modules
- Update the `include` paths in `workflows/cellpainting.nf` and the `script` paths in each module's `tests/main.nf.test`

## Test plan
- [x] `nf-test test modules/local/cellprofiler/analysis/tests/main.nf.test modules/local/cellprofiler/assaydevelopment/tests/main.nf.test --profile test,docker --tag stub` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)