### PR TITLE
test(cytotable): assert pipeline-level QC counts via stats JSON

### DIFF
--- a/modules/local/cytotable/main.nf
+++ b/modules/local/cytotable/main.nf
@@ -47,7 +47,7 @@ convert(
 parquet_metadata = pq.read_metadata(dest_path)
 column_names = parquet_metadata.schema.to_arrow_schema().names
 
-# \$ is Nextflow's dollar-escape; Python re sees a bare \$ (end-of-string anchor).
+# \$ is Nextflow's escape for the regex end-of-string anchor used below.
 channel_pattern = re.compile(r"^Cells_Intensity_MeanIntensity_([A-Za-z0-9]+)\$")
 channels = {m.group(1) for name in column_names for m in [channel_pattern.match(name)] if m}
 

--- a/modules/local/cytotable/main.nf
+++ b/modules/local/cytotable/main.nf
@@ -10,34 +10,77 @@ process CYTOTABLE {
     tuple val(meta), path(cellprofiler_output_dir)
 
     output:
-    tuple val(meta), path("*.parquet")
+    tuple val(meta), path("*.parquet"),     emit: parquet
+    tuple val(meta), path("*_stats.json"),  emit: stats
 
     script:
+    def basename = "${meta.batch}_${meta.plate}_${meta.well}_${meta.site}"
     """
 #!/usr/bin/env python
+
+import json
+import os
+import re
 
 from cytotable import convert
 from parsl.config import Config
 from parsl.executors import ThreadPoolExecutor
+import pyarrow.parquet as pq
 
-import os
 current_dir = os.getcwd()
 os.environ["HOME"] = current_dir
+
+dest_path  = "${basename}.parquet"
+stats_path = "${basename}_stats.json"
 
 convert(
     source_path="${cellprofiler_output_dir}",
     source_datatype="csv",
-    dest_path="${meta.batch}_${meta.plate}_${meta.well}_${meta.site}.parquet",
+    dest_path=dest_path,
     dest_datatype="parquet",
     preset="cellprofiler_csv",
     parsl_config=Config(
         executors=[ThreadPoolExecutor(max_threads=${task.cpus})],
-    )
+    ),
 )
+
+table = pq.read_table(dest_path)
+
+channel_pattern = re.compile(r"^Cells_Intensity_MeanIntensity_([A-Za-z0-9]+)\$")
+channels = {m.group(1) for name in table.column_names for m in [channel_pattern.match(name)] if m}
+
+stats = {
+    "metadata": {
+        "batch": "${meta.batch}",
+        "plate": "${meta.plate}",
+        "well":  "${meta.well}",
+        "site":  "${meta.site}",
+    },
+    "num_cells":    table.num_rows,
+    "num_channels": len(channels),
+    "num_columns":  table.num_columns,
+}
+
+with open(stats_path, "w") as f:
+    json.dump(stats, f, indent=2, sort_keys=True)
     """
 
     stub:
+    def basename = "${meta.batch}_${meta.plate}_${meta.well}_${meta.site}"
     """
-    touch ${meta.batch}_${meta.plate}_${meta.well}_${meta.site}.parquet
+    touch ${basename}.parquet
+    cat > ${basename}_stats.json <<'JSON'
+    {
+      "metadata": {
+        "batch": "${meta.batch}",
+        "plate": "${meta.plate}",
+        "well":  "${meta.well}",
+        "site":  "${meta.site}"
+      },
+      "num_cells": 0,
+      "num_channels": 0,
+      "num_columns": 0
+    }
+    JSON
     """
 }

--- a/modules/local/cytotable/main.nf
+++ b/modules/local/cytotable/main.nf
@@ -47,7 +47,7 @@ convert(
 parquet_metadata = pq.read_metadata(dest_path)
 column_names = parquet_metadata.schema.to_arrow_schema().names
 
-# \$ is Nextflow's dollar-escape; Python re sees a bare $ (end-of-string anchor).
+# \$ is Nextflow's dollar-escape; Python re sees a bare \$ (end-of-string anchor).
 channel_pattern = re.compile(r"^Cells_Intensity_MeanIntensity_([A-Za-z0-9]+)\$")
 channels = {m.group(1) for name in column_names for m in [channel_pattern.match(name)] if m}
 

--- a/modules/local/cytotable/main.nf
+++ b/modules/local/cytotable/main.nf
@@ -44,10 +44,12 @@ convert(
     ),
 )
 
-table = pq.read_table(dest_path)
+parquet_metadata = pq.read_metadata(dest_path)
+column_names = parquet_metadata.schema.to_arrow_schema().names
 
+# \$ is Nextflow's dollar-escape; Python re sees a bare $ (end-of-string anchor).
 channel_pattern = re.compile(r"^Cells_Intensity_MeanIntensity_([A-Za-z0-9]+)\$")
-channels = {m.group(1) for name in table.column_names for m in [channel_pattern.match(name)] if m}
+channels = {m.group(1) for name in column_names for m in [channel_pattern.match(name)] if m}
 
 stats = {
     "metadata": {
@@ -56,9 +58,9 @@ stats = {
         "well":  "${meta.well}",
         "site":  "${meta.site}",
     },
-    "num_cells":    table.num_rows,
+    "num_cells":    parquet_metadata.num_rows,
     "num_channels": len(channels),
-    "num_columns":  table.num_columns,
+    "num_columns":  parquet_metadata.num_columns,
 }
 
 with open(stats_path, "w") as f:

--- a/modules/local/cytotable/meta.yml
+++ b/modules/local/cytotable/meta.yml
@@ -19,5 +19,13 @@ output:
       - "*.parquet":
           type: file
           description: parquet file format.
+  - stats:
+      - "*_stats.json":
+          type: file
+          description: |
+            JSON file containing per-parquet QC counts: num_cells (row count),
+            num_channels (distinct intensity channels detected via
+            Cells_Intensity_MeanIntensity_* column names), num_columns (total
+            column count), and a metadata echo of batch, plate, well, and site.
 authors:
   - "@ybaeus"

--- a/modules/local/cytotable/tests/main.nf.test
+++ b/modules/local/cytotable/tests/main.nf.test
@@ -24,10 +24,13 @@ nextflow_process {
         }
 
         then {
-            assert process.success
-            assert snapshot(process.out).match("*.parquet")
-
-
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.parquet,
+                    process.out.stats,
+                ).match() }
+            )
         }
 
     }
@@ -53,7 +56,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.parquet,
+                    process.out.stats,
+                ).match() }
             )
         }
     }

--- a/modules/local/cytotable/tests/main.nf.test.snap
+++ b/modules/local/cytotable/tests/main.nf.test.snap
@@ -1,46 +1,64 @@
 {
     "cytotable - stub": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "batch": "2021_04_26_Batch1",
-                            "plate": "BR00117035",
-                            "well": "A01",
-                            "site": "1"
-                        },
-                        "2021_04_26_Batch1_BR00117035_A01_1.parquet:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+            [
+                [
+                    {
+                        "batch": "2021_04_26_Batch1",
+                        "plate": "BR00117035",
+                        "well": "A01",
+                        "site": "1"
+                    },
+                    "2021_04_26_Batch1_BR00117035_A01_1.parquet:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "batch": "2021_04_26_Batch1",
+                        "plate": "BR00117035",
+                        "well": "A01",
+                        "site": "1"
+                    },
+                    "2021_04_26_Batch1_BR00117035_A01_1_stats.json:md5,64e2e010e091a7107eb1580b6172cd1e"
+                ]
+            ]
         ],
         "meta": {
             "nf-test": "0.9.1",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-04-01T16:35:12.452789"
+        "timestamp": "2026-04-28T15:34:50.426603"
     },
-    "*.parquet": {
+    "Should run without failures": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "batch": "2021_04_26_Batch1",
-                            "plate": "BR00117035",
-                            "well": "A01",
-                            "site": "1"
-                        },
-                        "2021_04_26_Batch1_BR00117035_A01_1.parquet:md5,2ca5fe9f60ab445ee3ed458729725c03"
-                    ]
+            [
+                [
+                    {
+                        "batch": "2021_04_26_Batch1",
+                        "plate": "BR00117035",
+                        "well": "A01",
+                        "site": "1"
+                    },
+                    "2021_04_26_Batch1_BR00117035_A01_1.parquet:md5,2ca5fe9f60ab445ee3ed458729725c03"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "batch": "2021_04_26_Batch1",
+                        "plate": "BR00117035",
+                        "well": "A01",
+                        "site": "1"
+                    },
+                    "2021_04_26_Batch1_BR00117035_A01_1_stats.json:md5,b738ef7a64a42c07afd33fad8515649d"
+                ]
+            ]
         ],
         "meta": {
             "nf-test": "0.9.1",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-04-01T16:35:07.784117"
+        "timestamp": "2026-04-28T15:35:55.213567"
     }
 }

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -14,6 +14,11 @@
 # CYTOTABLE parquets are derived from the per-cell CSVs above and inherit
 # the same BLAS-driven drift. Tracked in #41.
 cytotable/*.parquet
+# CYTOTABLE per-parquet stats JSONs contain only integer counts, but we
+# assert on parsed structure rather than file md5 so changes to one count
+# value can be expressed as targeted test edits instead of opaque snapshot
+# churn. Tracked alongside the corresponding parquet ignore above.
+cytotable/*_stats.json
 multiqc/multiqc_data/multiqc.parquet
 multiqc/multiqc_data/multiqc.log
 multiqc/multiqc_data/multiqc_data.json

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -33,8 +33,7 @@ nextflow_pipeline {
                 {
                     // Parse all CYTOTABLE per-site stats JSONs and assert structural QC counts.
                     // Spec: docs/superpowers/specs/2026-04-28-cytotable-stats-json-design.md
-                    def stats_dir   = file("$outputDir/cytotable")
-                    def stats_files = stats_dir.listFiles().findAll { it.name.endsWith('_stats.json') }
+                    def stats_files = files("$outputDir/cytotable/*_stats.json")
                     def all_stats   = stats_files.collect { path(it.toString()).json }
 
                     // Test fixture: 3 wells x 2 sites = 6 site-level parquets.

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -33,7 +33,8 @@ nextflow_pipeline {
                 {
                     // Parse all CYTOTABLE per-site stats JSONs and assert structural QC counts.
                     // Spec: docs/superpowers/specs/2026-04-28-cytotable-stats-json-design.md
-                    def stats_files = files("$outputDir/cytotable/*_stats.json")
+                    def stats_dir   = file("$outputDir/cytotable")
+                    def stats_files = stats_dir.exists() ? stats_dir.listFiles().findAll { it.name.endsWith('_stats.json') } : []
                     def all_stats   = stats_files.collect { path(it.toString()).json }
 
                     // Test fixture: 3 wells x 2 sites = 6 site-level parquets.
@@ -55,21 +56,16 @@ nextflow_pipeline {
                     assert channel_counts.size() == 1 : "num_channels disagrees across sites: ${channel_counts}"
 
                     // Total cell count: BLAS drift can flip a handful of segmentation edge
-                    // cells, so we allow 1% tolerance against an observed baseline. Run this
-                    // test once with the placeholder values below to capture the observed
-                    // numbers from the assertion failure messages, then replace them.
+                    // cells, so we allow 1% tolerance against an observed baseline.
                     def total_cells           = all_stats.sum { it.num_cells }
                     def observed_num_channels = channel_counts.first()
-                    println "[cytotable stats] total_cells=${total_cells}, num_channels=${observed_num_channels}"
 
-                    def expected_total_cells  = 0  // TODO Task 5: replace with observed value
-                    def expected_num_channels = 0  // TODO Task 5: replace with observed value
-                    def tolerance             = 0.01  // 1%
+                    def expected_total_cells  = 832  // observed 2026-04-28 on Linux/Docker
+                    def expected_num_channels = 8    // observed 2026-04-28
+                    def tolerance             = 0.01 // 1%
 
                     assert observed_num_channels == expected_num_channels :
-                        "Set expected_num_channels = ${observed_num_channels} in tests/default.nf.test"
-                    assert expected_total_cells > 0 :
-                        "Set expected_total_cells = ${total_cells} in tests/default.nf.test (placeholder is 0)"
+                        "num_channels ${observed_num_channels} disagrees with baseline ${expected_num_channels}"
                     assert Math.abs(total_cells - expected_total_cells) / expected_total_cells < tolerance :
                         "total_cells ${total_cells} drifted >${tolerance*100}% from baseline ${expected_total_cells}"
                 }

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -29,6 +29,51 @@ nextflow_pipeline {
                     // All files with stable contents
                     stable_path
                 ).match() }
+                ,
+                {
+                    // Parse all CYTOTABLE per-site stats JSONs and assert structural QC counts.
+                    // Spec: docs/superpowers/specs/2026-04-28-cytotable-stats-json-design.md
+                    def stats_dir   = file("$outputDir/cytotable")
+                    def stats_files = stats_dir.listFiles().findAll { it.name.endsWith('_stats.json') }
+                    def all_stats   = stats_files.collect { path(it.toString()).json }
+
+                    // Test fixture: 3 wells x 2 sites = 6 site-level parquets.
+                    def expected_wells          = ['A01', 'A02', 'B01']
+                    def expected_sites_per_well = 2
+
+                    assert all_stats.size() == expected_wells.size() * expected_sites_per_well
+
+                    def observed_wells = all_stats.collect { it.metadata.well }.unique().sort()
+                    assert observed_wells == expected_wells
+
+                    expected_wells.each { w ->
+                        assert all_stats.count { it.metadata.well == w } == expected_sites_per_well
+                    }
+
+                    // Channel count is identical across all sites (a function of the imaging
+                    // protocol, not BLAS).
+                    def channel_counts = all_stats.collect { it.num_channels }.unique()
+                    assert channel_counts.size() == 1 : "num_channels disagrees across sites: ${channel_counts}"
+
+                    // Total cell count: BLAS drift can flip a handful of segmentation edge
+                    // cells, so we allow 1% tolerance against an observed baseline. Run this
+                    // test once with the placeholder values below to capture the observed
+                    // numbers from the assertion failure messages, then replace them.
+                    def total_cells           = all_stats.sum { it.num_cells }
+                    def observed_num_channels = channel_counts.first()
+                    println "[cytotable stats] total_cells=${total_cells}, num_channels=${observed_num_channels}"
+
+                    def expected_total_cells  = 0  // TODO Task 5: replace with observed value
+                    def expected_num_channels = 0  // TODO Task 5: replace with observed value
+                    def tolerance             = 0.01  // 1%
+
+                    assert observed_num_channels == expected_num_channels :
+                        "Set expected_num_channels = ${observed_num_channels} in tests/default.nf.test"
+                    assert expected_total_cells > 0 :
+                        "Set expected_total_cells = ${total_cells} in tests/default.nf.test (placeholder is 0)"
+                    assert Math.abs(total_cells - expected_total_cells) / expected_total_cells < tolerance :
+                        "total_cells ${total_cells} drifted >${tolerance*100}% from baseline ${expected_total_cells}"
+                }
             )
         }
     }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -95,11 +95,17 @@
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumRNA.npy",
                 "cytotable",
                 "cytotable/2021_04_26_Batch1_BR00117035_A01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_1_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_A01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_2_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_A02_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_1_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_A02_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_2_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_B01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_1_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_2_stats.json",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -144,7 +150,7 @@
             "nf-test": "0.9.1",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-04-28T11:39:54.721462"
+        "timestamp": "2026-04-28T17:00:09.5803"
     },
     "-profile test -stub": {
         "content": [
@@ -223,11 +229,17 @@
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumRNA.npy",
                 "cytotable",
                 "cytotable/2021_04_26_Batch1_BR00117035_A01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_1_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_A01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_2_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_A02_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_1_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_A02_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_2_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_B01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_1_stats.json",
                 "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_2_stats.json",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_plots",
@@ -257,6 +269,6 @@
             "nf-test": "0.9.1",
             "nextflow": "25.10.0"
         },
-        "timestamp": "2026-04-28T11:41:35.247037"
+        "timestamp": "2026-04-28T17:03:07.163024"
     }
 }


### PR DESCRIPTION
## Summary
- `CYTOTABLE` process now emits a sibling `*_stats.json` per parquet, computed via pyarrow inside the existing cytotable container — counts only (`num_cells`, `num_channels`, `num_columns`, plus a `metadata` echo). No per-column means.
- Pipeline-level nf-test parses each per-site stats JSON and asserts wells/sites/channel-consistency exactly, and `total_cells` within ±1% of an observed baseline (832 cells, 8 channels on Linux/Docker 2026-04-28).
- Replaces blanket `cytotable/*.parquet` md5-ignore with prescriptive structural coverage. Both `*.parquet` and `*_stats.json` remain in `tests/.nftignore` for md5 (BLAS-driven floating-point drift makes byte-level comparison meaningless), but content is now explicitly verified by parsed assertions.
- Module-level cytotable test now snapshots both `parquet` and `stats` outputs by name; both md5s are deterministic on the fixed S3 input.

## Test plan
- [x] `nf-test test tests/default.nf.test modules/local --profile test,docker --tag stub` — 5/5 PASS (2m39s)
- [x] `nf-test test tests/default.nf.test modules/local --profile test,docker` — 10/10 PASS (18m04s)
- [x] `nf-core pipelines lint --dir .` — 224 pass / 7 pre-existing failures / 0 new

## Out of scope
Image / Experiment / Cells / Cytoplasm / Nuclei CSV structural assertions are deferred to a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)