### PR TITLE
feat: add plate montage and interactive plate viewer

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -45,6 +45,21 @@ process {
         ]
     }
 
+    withName: 'IMAGEMAGICK_MONTAGE' {
+        publishDir = [
+            [
+                path: { "${params.outdir}/imagemagick/montage/thumbnail" },
+                mode: params.publish_dir_mode,
+                pattern: '*_montage_mqc.png'
+            ],
+            [
+                path: { "${params.outdir}/imagemagick/montage/full" },
+                mode: params.publish_dir_mode,
+                pattern: '*_montage_full.tiff'
+            ]
+        ]
+    }
+
     withName: 'CYTOTABLE' {
         publishDir = [
             path: { "${params.outdir}/cytotable" },

--- a/modules/local/cellprofiler/assaydevelopment/main.nf
+++ b/modules/local/cellprofiler/assaydevelopment/main.nf
@@ -47,7 +47,7 @@ process CELLPROFILER_ASSAYDEVELOPMENT {
     stub:
     """
     mkdir -p assaydevelopment
-    echo 'stub' > assaydevelopment/mock_segmentedimage.png
+    echo 'stub' > assaydevelopment/${meta.batch}_${meta.plate}_${meta.well}_ObjectOverlay.png
     echo 'ImageNumber,Metadata_Plate' > assaydevelopment/Image.csv
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap
+++ b/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                             "well": "A01",
                             "site": 1
                         },
-                        "mock_segmentedimage.png:md5,f50b84b1db4b83ba62ec1deacc69c260"
+                        "2021_04_26_Batch1_BR00117035_A01_ObjectOverlay.png:md5,f50b84b1db4b83ba62ec1deacc69c260"
                     ]
                 ],
                 "1": [
@@ -50,7 +50,7 @@
                             "well": "A01",
                             "site": 1
                         },
-                        "mock_segmentedimage.png:md5,f50b84b1db4b83ba62ec1deacc69c260"
+                        "2021_04_26_Batch1_BR00117035_A01_ObjectOverlay.png:md5,f50b84b1db4b83ba62ec1deacc69c260"
                     ]
                 ],
                 "versions": [
@@ -59,10 +59,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-01T16:34:38.445556"
+        "timestamp": "2026-04-29T12:11:35.873819"
     },
     "cellprofiler - assay development": {
         "content": [

--- a/modules/local/imagemagick/montage/environment.yml
+++ b/modules/local/imagemagick/montage/environment.yml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+dependencies:
+  - "conda-forge::imagemagick=7.1.2"

--- a/modules/local/imagemagick/montage/main.nf
+++ b/modules/local/imagemagick/montage/main.nf
@@ -3,8 +3,6 @@ process IMAGEMAGICK_MONTAGE {
     label 'process_single' // montage is single-threaded (OpenMP disabled in conda-forge build)
 
     conda "${moduleDir}/environment.yml"
-    // Multi-arch manifest (linux/amd64 + linux/arm64), built via:
-    //   wave --conda-package conda-forge::imagemagick=7.1.2 --platform linux/amd64,linux/arm64 --freeze --await
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'oras://community.wave.seqera.io/library/imagemagick:imagemagick-7.1.2--d0b725a537542464' :
         'community.wave.seqera.io/library/imagemagick:imagemagick-7.1.2--d0b725a537542464' }"

--- a/modules/local/imagemagick/montage/main.nf
+++ b/modules/local/imagemagick/montage/main.nf
@@ -1,0 +1,147 @@
+process IMAGEMAGICK_MONTAGE {
+    tag "$meta.id"
+    label 'process_single' // montage is single-threaded (OpenMP disabled in conda-forge build)
+
+    conda "${moduleDir}/environment.yml"
+    // Multi-arch manifest (linux/amd64 + linux/arm64), built via:
+    //   wave --conda-package conda-forge::imagemagick=7.1.2 --platform linux/amd64,linux/arm64 --freeze --await
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://community.wave.seqera.io/library/imagemagick:imagemagick-7.1.2--d0b725a537542464' :
+        'community.wave.seqera.io/library/imagemagick:imagemagick-7.1.2--d0b725a537542464' }"
+
+    input:
+    tuple val(meta), val(wells_meta), path(pngs, stageAs: "images/*"), val(plate_rows), val(plate_cols)
+
+    output:
+    tuple val(meta), path("*_montage_mqc.png"),  emit: montage
+    tuple val(meta), path("*_montage_full.tiff"), emit: montage_full, optional: true
+
+    tuple val("${task.process}"), val('imagemagick'), eval("montage -version | sed -n 's/^Version: ImageMagick //p' | cut -d' ' -f1"), topic: versions, emit: versions_imagemagick
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args      = task.ext.args ?: ''
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def full_res  = task.ext.full_res ?: false
+
+    // wells_meta and pngs are parallel lists — write a well->file TSV for bash
+    def png_list = pngs instanceof List ? pngs : [pngs]
+    def mapping_lines = []
+    wells_meta.eachWithIndex { w, idx ->
+        if (idx < png_list.size()) {
+            mapping_lines << w.well + '\t' + png_list[idx].name
+        }
+    }
+    def mapping_tsv = mapping_lines.join('\n')
+
+    // Plate grid well names (A01, A02, ..., P24) and header labels
+    def plate_grid = []
+    (1..plate_rows).each { int r ->
+        (1..plate_cols).each { int c ->
+            plate_grid << "" + (char)((int)('A' as char) + r - 1) + String.format('%02d', c)
+        }
+    }
+
+    def row_letters = (0..<plate_rows).collect { int i -> "" + (char)((int)('A' as char) + i) }
+    def col_numbers = (1..plate_cols).collect { int i -> i.toString() }
+
+    """
+    FONT=\$(fc-list : file | head -1 | cut -d: -f1)
+
+    # Build well -> staged file lookup from channel metadata
+    declare -A WELL_FILE
+    while IFS=\$'\\t' read -r WELL FILENAME; do
+        WELL_FILE[\$WELL]="\$FILENAME"
+    done <<< "${mapping_tsv}"
+
+    # Emit file list in plate-grid order (null: for missing wells)
+    > montage_args.txt
+    for WELL in ${plate_grid.join(' ')}; do
+        if [ -n "\${WELL_FILE[\$WELL]+x}" ]; then
+            echo "\${WELL_FILE[\$WELL]}" >> montage_args.txt
+        else
+            echo "null:"     >> montage_args.txt
+        fi
+    done
+
+    # Annotate montage with plate-style row/column headers
+    export FONT
+    add_plate_headers() {
+        local INPUT="\$1" OUTPUT="\$2" TILE_SZ="\$3"
+        local POINTSIZE=\$((TILE_SZ / 2))
+        local CELL_SZ=\$((TILE_SZ + 2 * 2))
+        local MARGIN_LEFT=\$((POINTSIZE + 8))
+        local MARGIN_TOP=\$((POINTSIZE + 4))
+
+        # Center labels over each cell using approximate glyph metrics
+        local HALF_GLYPH_W=\$((POINTSIZE / 3))
+        local HALF_GLYPH_H=\$((POINTSIZE / 3))
+
+        local COL_ANNOT="" ROW_ANNOT=""
+        local IDX=0
+        for COL_NUM in ${col_numbers.join(' ')}; do
+            local NUM_DIGITS=\${#COL_NUM}
+            local TEXT_W=\$((HALF_GLYPH_W * NUM_DIGITS))
+            local X=\$((MARGIN_LEFT + IDX * CELL_SZ + CELL_SZ / 2 - TEXT_W))
+            COL_ANNOT="\$COL_ANNOT -annotate +\${X}+2 '\$COL_NUM'"
+            IDX=\$((IDX + 1))
+        done
+        IDX=0
+        for ROW_LTR in ${row_letters.join(' ')}; do
+            local Y=\$((MARGIN_TOP + IDX * CELL_SZ + CELL_SZ / 2 - HALF_GLYPH_H))
+            ROW_ANNOT="\$ROW_ANNOT -annotate +4+\${Y} '\$ROW_LTR'"
+            IDX=\$((IDX + 1))
+        done
+
+        eval magick "\$INPUT" \\
+            -gravity northwest \\
+            -splice \${MARGIN_LEFT}x\${MARGIN_TOP} \\
+            -fill white -font "\$FONT" -pointsize "\$POINTSIZE" \\
+            \$COL_ANNOT \$ROW_ANNOT \\
+            "\$OUTPUT"
+    }
+
+    # Thumbnail montage — tiles resized during assembly to keep memory low
+    montage \\
+        \$(cat montage_args.txt | tr '\\n' ' ') \\
+        -tile ${plate_cols}x${plate_rows} \\
+        -geometry 200x200+2+2 \\
+        -font "\$FONT" \\
+        -background black \\
+        +label \\
+        ${args} \\
+        montage_raw.png
+
+    add_plate_headers montage_raw.png ${prefix}_montage_mqc.png 200
+    rm montage_raw.png
+
+    # Optional full-res montage (off by default — expensive for large plates)
+    if [ "${full_res}" = "true" ]; then
+        montage \\
+            \$(cat montage_args.txt | tr '\\n' ' ') \\
+            -tile ${plate_cols}x${plate_rows} \\
+            -geometry +2+2 \\
+            -font "\$FONT" \\
+            -background black \\
+            +label \\
+            ${args} \\
+            montage_full_raw.tiff
+
+        FULL_TILE_SZ=\$(magick identify -format '%w' \$(grep -v null montage_args.txt | head -1) 2>/dev/null || echo 200)
+        add_plate_headers montage_full_raw.tiff ${prefix}_montage_full.tiff \$FULL_TILE_SZ
+        rm montage_full_raw.tiff
+    fi
+    """
+
+    stub:
+    def prefix   = task.ext.prefix ?: "${meta.id}"
+    def full_res = task.ext.full_res ?: false
+    """
+    touch ${prefix}_montage_mqc.png
+    if [ "${full_res}" = "true" ]; then
+        touch ${prefix}_montage_full.tiff
+    fi
+    """
+}

--- a/modules/local/imagemagick/montage/meta.yml
+++ b/modules/local/imagemagick/montage/meta.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "imagemagick_montage"
-description: Generate a plate-grid montage from per-well overlay PNGs for visual QC
+description: >
+  Generate a plate-grid montage from per-well overlay PNGs for visual QC.
+  Each well shows a single representative site (controlled by
+  cellprofiler_assaydevelopment_site) with all channels composited into
+  one segmentation overlay image.
 keywords:
   - montage
   - plate

--- a/modules/local/imagemagick/montage/meta.yml
+++ b/modules/local/imagemagick/montage/meta.yml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "imagemagick_montage"
+description: Generate a plate-grid montage from per-well overlay PNGs for visual QC
+keywords:
+  - montage
+  - plate
+  - qc
+  - cell-painting
+  - imaging
+tools:
+  - "imagemagick":
+      description: "Software suite to create, edit, compose, or convert bitmap images"
+      homepage: "https://imagemagick.org"
+      documentation: "https://imagemagick.org/script/montage.php"
+      tool_dev_url: "https://github.com/ImageMagick/ImageMagick"
+      licence: ["Apache-2.0"]
+      identifier: biotools:imagemagick
+      args_id: "$args"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing plate information.
+          e.g. `[ id:'2021_04_26_Batch1_BR00117035', batch:'2021_04_26_Batch1', plate:'BR00117035' ]`
+    - wells_meta:
+        type: list
+        description: |
+          List of maps describing each well's position.
+          e.g. `[ [well:'A01', row:1, col:1], [well:'A02', row:1, col:2] ]`
+    - pngs:
+        type: file
+        description: Per-well overlay PNG files from assay development
+        pattern: "*.png"
+    - plate_rows:
+        type: integer
+        description: Number of rows in the plate grid (auto-detected from samplesheet)
+    - plate_cols:
+        type: integer
+        description: Number of columns in the plate grid (auto-detected from samplesheet)
+
+output:
+  montage:
+    - - meta:
+          type: map
+          description: Groovy Map containing plate information
+      - "*_montage_mqc.png":
+          type: file
+          description: Downscaled plate-grid montage PNG for MultiQC embedding
+          pattern: "*_montage_mqc.png"
+  montage_full:
+    - - meta:
+          type: map
+          description: Groovy Map containing plate information
+      - "*_montage_full.tiff":
+          type: file
+          description: Full-resolution plate-grid montage TIFF (lossless)
+          pattern: "*_montage_full.tiff"
+  versions_imagemagick:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - imagemagick:
+          type: string
+          description: The name of the tool
+      - "montage -version | sed -n 's/^Version: ImageMagick //p' | awk '{print $1}'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - imagemagick:
+          type: string
+          description: The name of the tool
+      - "montage -version | sed -n 's/^Version: ImageMagick //p' | awk '{print $1}'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@benjibromberg"
+maintainers:
+  - "@benjibromberg"

--- a/modules/local/imagemagick/montage/tests/main.nf.test
+++ b/modules/local/imagemagick/montage/tests/main.nf.test
@@ -1,0 +1,148 @@
+nextflow_process {
+
+    name "Test Process IMAGEMAGICK_MONTAGE"
+    script "../main.nf"
+    process "IMAGEMAGICK_MONTAGE"
+
+    tag "modules"
+    tag "modules_local"
+    tag "imagemagick"
+    tag "imagemagick/montage"
+
+    test("imagemagick - montage - 96 well plate thumbnail") {
+        when {
+            process {
+                """
+                def srcPng = file(params.pipelines_testdata_base_path + '/minimal_dataset/cpg0016-jump/source_4/workspace/assaydev/BR00117035-A01/BR00117035A01.png', checkIfExists: true)
+
+                def wells_meta = []
+                def pngs = []
+                ('A'..'H').each { row ->
+                    (1..12).each { col ->
+                        def well = row + String.format('%02d', col)
+                        def wellPng = workDir.resolve("Batch1_Plate96_\${well}_ObjectOverlay.png")
+                        java.nio.file.Files.copy(srcPng, wellPng, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                        wells_meta << [well: well, row: (row as char) - ('A' as char) + 1, col: col]
+                        pngs << wellPng
+                    }
+                }
+                input[0] = [
+                    [id:'Batch1_Plate96', batch:'Batch1', plate:'Plate96'],
+                    wells_meta,
+                    pngs,
+                    8, 12
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.montage },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("imagemagick - montage - 4 well plate full resolution") {
+        config './nextflow.config'
+        when {
+            params {
+                montage_full_res = true
+            }
+            process {
+                """
+                def srcPng = file(params.pipelines_testdata_base_path + '/minimal_dataset/cpg0016-jump/source_4/workspace/assaydev/BR00117035-A01/BR00117035A01.png', checkIfExists: true)
+
+                def wells_meta = []
+                def pngs = []
+                ('A'..'B').each { row ->
+                    (1..2).each { col ->
+                        def well = row + String.format('%02d', col)
+                        def wellPng = workDir.resolve("Batch1_Plate4_\${well}_ObjectOverlay.png")
+                        java.nio.file.Files.copy(srcPng, wellPng, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                        wells_meta << [well: well, row: (row as char) - ('A' as char) + 1, col: col]
+                        pngs << wellPng
+                    }
+                }
+                input[0] = [
+                    [id:'Batch1_Plate4', batch:'Batch1', plate:'Plate4'],
+                    wells_meta,
+                    pngs,
+                    2, 2
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.montage },
+                { assert process.out.montage_full },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("imagemagick - montage - 24 well plate sparse (18 of 24 wells)") {
+        when {
+            process {
+                """
+                def srcPng = file(params.pipelines_testdata_base_path + '/minimal_dataset/cpg0016-jump/source_4/workspace/assaydev/BR00117035-A01/BR00117035A01.png', checkIfExists: true)
+
+                // Populate 18 of 24 wells — skip A03, B02, C01, C05, D04, D06
+                def skip = ['A03', 'B02', 'C01', 'C05', 'D04', 'D06'] as Set
+                def wells_meta = []
+                def pngs = []
+                ('A'..'D').each { row ->
+                    (1..6).each { col ->
+                        def well = row + String.format('%02d', col)
+                        if (!skip.contains(well)) {
+                            def wellPng = workDir.resolve("Batch1_Plate24_\${well}_ObjectOverlay.png")
+                            java.nio.file.Files.copy(srcPng, wellPng, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                            wells_meta << [well: well, row: (row as char) - ('A' as char) + 1, col: col]
+                            pngs << wellPng
+                        }
+                    }
+                }
+                input[0] = [
+                    [id:'Batch1_Plate24', batch:'Batch1', plate:'Plate24'],
+                    wells_meta,
+                    pngs,
+                    4, 6
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.montage },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("imagemagick - montage - stub") {
+        tag "stub"
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:'Batch1_Plate1', batch:'Batch1', plate:'Plate1'],
+                    [[well:'A01', row:1, col:1], [well:'A02', row:1, col:2], [well:'B01', row:2, col:1]],
+                    [file("dummy_A01_overlay.png"), file("dummy_A02_overlay.png"), file("dummy_B01_overlay.png")],
+                    2, 2
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/local/imagemagick/montage/tests/main.nf.test
+++ b/modules/local/imagemagick/montage/tests/main.nf.test
@@ -39,7 +39,9 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert process.out.montage },
-                { assert snapshot(process.out).match() }
+                { assert path(process.out.montage[0][1]).exists() },
+                { assert path(process.out.montage[0][1]).toFile().length() > 0 },
+                { assert snapshot(process.out.versions_imagemagick).match() }
             )
         }
     }
@@ -79,7 +81,8 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.montage },
                 { assert process.out.montage_full },
-                { assert snapshot(process.out).match() }
+                { assert path(process.out.montage_full[0][1]).exists() },
+                { assert snapshot(process.out.versions_imagemagick).match() }
             )
         }
     }
@@ -118,7 +121,8 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert process.out.montage },
-                { assert snapshot(process.out).match() }
+                { assert path(process.out.montage[0][1]).exists() },
+                { assert snapshot(process.out.versions_imagemagick).match() }
             )
         }
     }

--- a/modules/local/imagemagick/montage/tests/main.nf.test.snap
+++ b/modules/local/imagemagick/montage/tests/main.nf.test.snap
@@ -52,169 +52,50 @@
     },
     "imagemagick - montage - 24 well plate sparse (18 of 24 wells)": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "Batch1_Plate24",
-                            "batch": "Batch1",
-                            "plate": "Plate24"
-                        },
-                        "Batch1_Plate24_montage_mqc.png:md5,a9d851759bcae8fb8b27363f22cf37f5"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    [
-                        "IMAGEMAGICK_MONTAGE",
-                        "imagemagick",
-                        "7.1.2-21"
-                    ]
-                ],
-                "montage": [
-                    [
-                        {
-                            "id": "Batch1_Plate24",
-                            "batch": "Batch1",
-                            "plate": "Plate24"
-                        },
-                        "Batch1_Plate24_montage_mqc.png:md5,a9d851759bcae8fb8b27363f22cf37f5"
-                    ]
-                ],
-                "montage_full": [
-                    
-                ],
-                "versions_imagemagick": [
-                    [
-                        "IMAGEMAGICK_MONTAGE",
-                        "imagemagick",
-                        "7.1.2-21"
-                    ]
+            [
+                [
+                    "IMAGEMAGICK_MONTAGE",
+                    "imagemagick",
+                    "7.1.2-21"
                 ]
-            }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T01:52:43.164055"
+        "timestamp": "2026-04-29T14:31:58.45139"
     },
     "imagemagick - montage - 96 well plate thumbnail": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "Batch1_Plate96",
-                            "batch": "Batch1",
-                            "plate": "Plate96"
-                        },
-                        "Batch1_Plate96_montage_mqc.png:md5,8a685dbdb2d9eaedee32671abdc6f1ef"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    [
-                        "IMAGEMAGICK_MONTAGE",
-                        "imagemagick",
-                        "7.1.2-21"
-                    ]
-                ],
-                "montage": [
-                    [
-                        {
-                            "id": "Batch1_Plate96",
-                            "batch": "Batch1",
-                            "plate": "Plate96"
-                        },
-                        "Batch1_Plate96_montage_mqc.png:md5,8a685dbdb2d9eaedee32671abdc6f1ef"
-                    ]
-                ],
-                "montage_full": [
-                    
-                ],
-                "versions_imagemagick": [
-                    [
-                        "IMAGEMAGICK_MONTAGE",
-                        "imagemagick",
-                        "7.1.2-21"
-                    ]
+            [
+                [
+                    "IMAGEMAGICK_MONTAGE",
+                    "imagemagick",
+                    "7.1.2-21"
                 ]
-            }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T01:52:19.852555"
+        "timestamp": "2026-04-29T14:31:40.449879"
     },
     "imagemagick - montage - 4 well plate full resolution": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "Batch1_Plate4",
-                            "batch": "Batch1",
-                            "plate": "Plate4"
-                        },
-                        "Batch1_Plate4_montage_mqc.png:md5,a5c29c7d15b7195f51864b558b74d50c"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "Batch1_Plate4",
-                            "batch": "Batch1",
-                            "plate": "Plate4"
-                        },
-                        "Batch1_Plate4_montage_full.png:md5,e93a50846d424b524421764bc9776d4e"
-                    ]
-                ],
-                "2": [
-                    [
-                        "IMAGEMAGICK_MONTAGE",
-                        "imagemagick",
-                        "7.1.2-21"
-                    ]
-                ],
-                "montage": [
-                    [
-                        {
-                            "id": "Batch1_Plate4",
-                            "batch": "Batch1",
-                            "plate": "Plate4"
-                        },
-                        "Batch1_Plate4_montage_mqc.png:md5,a5c29c7d15b7195f51864b558b74d50c"
-                    ]
-                ],
-                "montage_full": [
-                    [
-                        {
-                            "id": "Batch1_Plate4",
-                            "batch": "Batch1",
-                            "plate": "Plate4"
-                        },
-                        "Batch1_Plate4_montage_full.png:md5,e93a50846d424b524421764bc9776d4e"
-                    ]
-                ],
-                "versions_imagemagick": [
-                    [
-                        "IMAGEMAGICK_MONTAGE",
-                        "imagemagick",
-                        "7.1.2-21"
-                    ]
+            [
+                [
+                    "IMAGEMAGICK_MONTAGE",
+                    "imagemagick",
+                    "7.1.2-21"
                 ]
-            }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T01:52:31.892259"
+        "timestamp": "2026-04-29T14:31:46.612347"
     }
 }

--- a/modules/local/imagemagick/montage/tests/main.nf.test.snap
+++ b/modules/local/imagemagick/montage/tests/main.nf.test.snap
@@ -1,0 +1,220 @@
+{
+    "imagemagick - montage - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "Batch1_Plate1",
+                            "batch": "Batch1",
+                            "plate": "Plate1"
+                        },
+                        "Batch1_Plate1_montage_mqc.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ],
+                "montage": [
+                    [
+                        {
+                            "id": "Batch1_Plate1",
+                            "batch": "Batch1",
+                            "plate": "Plate1"
+                        },
+                        "Batch1_Plate1_montage_mqc.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "montage_full": [
+                    
+                ],
+                "versions_imagemagick": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-28T16:31:00.225367"
+    },
+    "imagemagick - montage - 24 well plate sparse (18 of 24 wells)": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "Batch1_Plate24",
+                            "batch": "Batch1",
+                            "plate": "Plate24"
+                        },
+                        "Batch1_Plate24_montage_mqc.png:md5,a9d851759bcae8fb8b27363f22cf37f5"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ],
+                "montage": [
+                    [
+                        {
+                            "id": "Batch1_Plate24",
+                            "batch": "Batch1",
+                            "plate": "Plate24"
+                        },
+                        "Batch1_Plate24_montage_mqc.png:md5,a9d851759bcae8fb8b27363f22cf37f5"
+                    ]
+                ],
+                "montage_full": [
+                    
+                ],
+                "versions_imagemagick": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-29T01:52:43.164055"
+    },
+    "imagemagick - montage - 96 well plate thumbnail": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "Batch1_Plate96",
+                            "batch": "Batch1",
+                            "plate": "Plate96"
+                        },
+                        "Batch1_Plate96_montage_mqc.png:md5,8a685dbdb2d9eaedee32671abdc6f1ef"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ],
+                "montage": [
+                    [
+                        {
+                            "id": "Batch1_Plate96",
+                            "batch": "Batch1",
+                            "plate": "Plate96"
+                        },
+                        "Batch1_Plate96_montage_mqc.png:md5,8a685dbdb2d9eaedee32671abdc6f1ef"
+                    ]
+                ],
+                "montage_full": [
+                    
+                ],
+                "versions_imagemagick": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-29T01:52:19.852555"
+    },
+    "imagemagick - montage - 4 well plate full resolution": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "Batch1_Plate4",
+                            "batch": "Batch1",
+                            "plate": "Plate4"
+                        },
+                        "Batch1_Plate4_montage_mqc.png:md5,a5c29c7d15b7195f51864b558b74d50c"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "Batch1_Plate4",
+                            "batch": "Batch1",
+                            "plate": "Plate4"
+                        },
+                        "Batch1_Plate4_montage_full.png:md5,e93a50846d424b524421764bc9776d4e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ],
+                "montage": [
+                    [
+                        {
+                            "id": "Batch1_Plate4",
+                            "batch": "Batch1",
+                            "plate": "Plate4"
+                        },
+                        "Batch1_Plate4_montage_mqc.png:md5,a5c29c7d15b7195f51864b558b74d50c"
+                    ]
+                ],
+                "montage_full": [
+                    [
+                        {
+                            "id": "Batch1_Plate4",
+                            "batch": "Batch1",
+                            "plate": "Plate4"
+                        },
+                        "Batch1_Plate4_montage_full.png:md5,e93a50846d424b524421764bc9776d4e"
+                    ]
+                ],
+                "versions_imagemagick": [
+                    [
+                        "IMAGEMAGICK_MONTAGE",
+                        "imagemagick",
+                        "7.1.2-21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-29T01:52:31.892259"
+    }
+}

--- a/modules/local/imagemagick/montage/tests/nextflow.config
+++ b/modules/local/imagemagick/montage/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'IMAGEMAGICK_MONTAGE' {
+        ext.full_res = params.montage_full_res
+    }
+}

--- a/modules/local/plateviewer/main.nf
+++ b/modules/local/plateviewer/main.nf
@@ -36,7 +36,7 @@ process PLATEVIEWER {
     html = f'''<!--
     id: "plate-montages"
     section_name: "Plate Montages"
-    description: "Segmentation overlay montages arranged in plate grid layout. Select a plate from the dropdown to view."
+    description: "Segmentation overlay montages arranged in plate grid layout. Each well shows a single representative site (controlled by <code>cellprofiler_assaydevelopment_site</code>, default site 1) with all channels composited into one overlay image. Select a plate from the dropdown to view."
     -->
     <div style="margin: 10px 0;">
         <label for="plate-select" style="font-weight: bold; margin-right: 8px;">Plate:</label>

--- a/modules/local/plateviewer/main.nf
+++ b/modules/local/plateviewer/main.nf
@@ -11,22 +11,26 @@ process PLATEVIEWER {
     task.ext.when == null || task.ext.when
 
     script:
-    def plate_ids_json = new groovy.json.JsonOutput().toJson(plate_ids)
+    // plate_ids and montage_pngs are parallel lists — build explicit mapping
+    def png_list = montage_pngs instanceof List ? montage_pngs : [montage_pngs]
+    def plate_map = [:]
+    plate_ids.eachWithIndex { id, idx ->
+        if (idx < png_list.size()) {
+            plate_map[id] = png_list[idx].name
+        }
+    }
+    def plate_map_json = new groovy.json.JsonOutput().toJson(plate_map)
     """
     #!/usr/bin/env python3
-    import base64, json, os, sys
+    import base64, json
 
-    plate_ids = json.loads('${plate_ids_json}')
-    png_files = sorted(f for f in os.listdir('.') if f.endswith('.png'))
+    plate_map = json.loads('${plate_map_json}')
 
-    if len(plate_ids) != len(png_files):
-        print(f"Warning: {len(plate_ids)} plate IDs but {len(png_files)} PNGs", file=sys.stderr)
-
-    # Base64-encode each plate montage
+    # Base64-encode each plate montage using the metadata-driven mapping
     plates = {}
-    for pid, png in zip(sorted(plate_ids), png_files):
-        with open(png, 'rb') as f:
-            plates[pid] = base64.b64encode(f.read()).decode()
+    for plate_id, filename in plate_map.items():
+        with open(filename, 'rb') as f:
+            plates[plate_id] = base64.b64encode(f.read()).decode()
 
     sorted_ids = sorted(plates.keys())
     options = ''.join(f'<option value="{pid}">{pid}</option>' for pid in sorted_ids)

--- a/modules/local/plateviewer/main.nf
+++ b/modules/local/plateviewer/main.nf
@@ -1,0 +1,75 @@
+process PLATEVIEWER {
+    label 'process_single'
+
+    input:
+    tuple val(plate_ids), path(montage_pngs)
+
+    output:
+    path "plate_montages_mqc.html", emit: html
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def plate_ids_json = new groovy.json.JsonOutput().toJson(plate_ids)
+    """
+    #!/usr/bin/env python3
+    import base64, json, os, sys
+
+    plate_ids = json.loads('${plate_ids_json}')
+    png_files = sorted(f for f in os.listdir('.') if f.endswith('.png'))
+
+    if len(plate_ids) != len(png_files):
+        print(f"Warning: {len(plate_ids)} plate IDs but {len(png_files)} PNGs", file=sys.stderr)
+
+    # Base64-encode each plate montage
+    plates = {}
+    for pid, png in zip(sorted(plate_ids), png_files):
+        with open(png, 'rb') as f:
+            plates[pid] = base64.b64encode(f.read()).decode()
+
+    sorted_ids = sorted(plates.keys())
+    options = ''.join(f'<option value="{pid}">{pid}</option>' for pid in sorted_ids)
+    first_img = plates[sorted_ids[0]]
+    plate_data_json = json.dumps({pid: plates[pid] for pid in sorted_ids})
+
+    html = f'''<!--
+    id: "plate-montages"
+    section_name: "Plate Montages"
+    description: "Segmentation overlay montages arranged in plate grid layout. Select a plate from the dropdown to view."
+    -->
+    <div style="margin: 10px 0;">
+        <label for="plate-select" style="font-weight: bold; margin-right: 8px;">Plate:</label>
+        <select id="plate-select" onchange="switchPlate(this.value)" style="padding: 4px 8px; font-size: 14px;">
+            {options}
+        </select>
+        <span style="margin-left: 12px; color: #999;">{len(sorted_ids)} plate(s)</span>
+    </div>
+    <details style="margin: 6px 0; font-size: 12px; color: #999;">
+        <summary>Output file locations</summary>
+        <ul style="margin: 4px 0;">
+            <li>Thumbnail montages: <code>imagemagick/montage/thumbnail/</code></li>
+            <li>Full-resolution montages (if enabled via <code>ext.full_res = true</code>): <code>imagemagick/montage/full/</code></li>
+            <li>Individual per-well overlays: <code>cellprofiler/assay_development/</code></li>
+        </ul>
+    </details>
+    <div>
+        <img id="plate-image" src="data:image/png;base64,{first_img}" style="max-width: 100%; border: 1px solid #333;" />
+    </div>
+    <script>
+        var plateData = {plate_data_json};
+        function switchPlate(plateId) {{
+            document.getElementById("plate-image").src = "data:image/png;base64," + plateData[plateId];
+        }}
+    </script>
+    '''
+
+    with open('plate_montages_mqc.html', 'w') as f:
+        f.write(html)
+    """
+
+    stub:
+    """
+    echo '<!-- stub -->' > plate_montages_mqc.html
+    """
+}

--- a/modules/local/plateviewer/meta.yml
+++ b/modules/local/plateviewer/meta.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "plateviewer"
-description: Aggregate plate montage PNGs into an interactive HTML viewer for MultiQC
+description: >
+  Aggregate plate montage PNGs into an interactive HTML viewer for MultiQC.
+  Each montage shows one representative site per well (controlled by
+  cellprofiler_assaydevelopment_site) with all channels composited into
+  one segmentation overlay image.
 keywords:
   - plate
   - montage

--- a/modules/local/plateviewer/meta.yml
+++ b/modules/local/plateviewer/meta.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "plateviewer"
+description: Aggregate plate montage PNGs into an interactive HTML viewer for MultiQC
+keywords:
+  - plate
+  - montage
+  - multiqc
+  - viewer
+  - qc
+input:
+  - - plate_ids:
+        type: list
+        description: List of plate identifier strings
+    - montage_pngs:
+        type: file
+        description: Plate montage PNG files (one per plate)
+        pattern: "*.png"
+output:
+  html:
+    - "plate_montages_mqc.html":
+        type: file
+        description: Self-contained HTML with dropdown plate selector for MultiQC embedding
+        pattern: "plate_montages_mqc.html"
+authors:
+  - "@benjibromberg"
+maintainers:
+  - "@benjibromberg"

--- a/modules/local/plateviewer/tests/main.nf.test
+++ b/modules/local/plateviewer/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process PLATEVIEWER"
+    script "../main.nf"
+    process "PLATEVIEWER"
+
+    tag "modules"
+    tag "modules_local"
+    tag "plateviewer"
+
+    test("plateviewer - 3 plates") {
+        when {
+            process {
+                """
+                def srcPng = file(params.pipelines_testdata_base_path + '/minimal_dataset/cpg0016-jump/source_4/workspace/assaydev/BR00117035-A01/BR00117035A01.png', checkIfExists: true)
+
+                def ids = ['Batch1_Plate1', 'Batch1_Plate2', 'Batch1_Plate3']
+                def pngs = ids.collect { id ->
+                    def p = workDir.resolve("\${id}_montage_mqc.png")
+                    java.nio.file.Files.copy(srcPng, p, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                    p
+                }
+                input[0] = [ids, pngs]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.html },
+                { assert path(process.out.html[0]).text.contains('plate-select') },
+                { assert path(process.out.html[0]).text.contains('Batch1_Plate1') },
+                { assert path(process.out.html[0]).text.contains('Batch1_Plate3') },
+            )
+        }
+    }
+
+    test("plateviewer - stub") {
+        tag "stub"
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    ['Batch1_Plate1'],
+                    [file("dummy_montage.png")]
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.html },
+            )
+        }
+    }
+}

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -14,6 +14,10 @@
 # CYTOTABLE parquets are derived from the per-cell CSVs above and inherit
 # the same BLAS-driven drift. Tracked in #41.
 cytotable/*.parquet
+# Montage PNGs and plate viewer HTML contain font-rendered text whose
+# pixel output differs between ARM and x86 (different freetype rendering).
+imagemagick/montage/**/*.png
+plateviewer/plate_montages_mqc.html
 multiqc/multiqc_data/multiqc.parquet
 multiqc/multiqc_data/multiqc.log
 multiqc/multiqc_data/multiqc_data.json

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -105,7 +105,9 @@
                 "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
                 "imagemagick",
                 "imagemagick/montage",
-                "imagemagick/montage/2021_04_26_Batch1_BR00117035_montage_mqc.png",
+                "imagemagick/montage/full",
+                "imagemagick/montage/thumbnail",
+                "imagemagick/montage/thumbnail/2021_04_26_Batch1_BR00117035_montage_mqc.png",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -145,16 +147,14 @@
                 "BR00117035_IllumER.npy:md5,75062bcc5f10eb9db2ee9e18b9fc4d40",
                 "BR00117035_IllumMito.npy:md5,d33a48d56045736f46a470f44955ff07",
                 "BR00117035_IllumRNA.npy:md5,c21cb042cfb15cc7ca939eef99d4ebd3",
-                "2021_04_26_Batch1_BR00117035_montage_mqc.png:md5,6577f6d755e7b007ccc20b2ea279ae0e",
-                "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "plate_montages_mqc.html:md5,9ace299df0cf84d9530795829827669f"
+                "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T02:12:33.838134"
+        "timestamp": "2026-04-29T15:28:36.626446"
     },
     "-profile test -stub": {
         "content": [

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -274,15 +274,13 @@
                 "BR00117035_IllumDNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "BR00117035_IllumER.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "BR00117035_IllumMito.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "BR00117035_IllumRNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "2021_04_26_Batch1_BR00117035_montage_mqc.png:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "plate_montages_mqc.html:md5,4bf6d7cff478bfd63ac32dd7442547cf"
+                "BR00117035_IllumRNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T12:08:01.374704"
+        "timestamp": "2026-04-29T14:52:21.494679"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -97,12 +97,7 @@
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumMito.npy",
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumRNA.npy",
                 "cytotable",
-                "cytotable/2021_04_26_Batch1_BR00117035_A01_1.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_A01_2.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_A02_1.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_A02_2.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_B01_1.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035.parquet",
                 "imagemagick",
                 "imagemagick/montage",
                 "imagemagick/montage/full",
@@ -150,11 +145,11 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
+        "timestamp": "2026-04-30T00:47:51.296500534",
         "meta": {
-            "nf-test": "0.9.3",
+            "nf-test": "0.9.5",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-04-29T15:28:36.626446"
+        }
     },
     "-profile test -stub": {
         "content": [
@@ -237,12 +232,7 @@
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumMito.npy",
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumRNA.npy",
                 "cytotable",
-                "cytotable/2021_04_26_Batch1_BR00117035_A01_1.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_A01_2.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_A02_1.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_A02_2.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_B01_1.parquet",
-                "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035.parquet",
                 "imagemagick",
                 "imagemagick/montage",
                 "imagemagick/montage/full",
@@ -277,10 +267,10 @@
                 "BR00117035_IllumRNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
+        "timestamp": "2026-04-29T23:50:40.756411",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-04-29T14:52:21.494679"
+        }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -11,6 +11,9 @@
                 "CELLPROFILER_ILLUMINATIONCORRECTION": {
                     "cellprofiler": "4.2.8"
                 },
+                "IMAGEMAGICK_MONTAGE": {
+                    "imagemagick": "7.1.2-21"
+                },
                 "Workflow": {
                     "nf-core/cellpainting": "v1.0.0dev"
                 }
@@ -94,7 +97,15 @@
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumMito.npy",
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumRNA.npy",
                 "cytotable",
-                "cytotable/2021_04_26_Batch1_BR00117035.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
+                "imagemagick",
+                "imagemagick/montage",
+                "imagemagick/montage/2021_04_26_Batch1_BR00117035_montage_mqc.png",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -106,7 +117,9 @@
                 "multiqc/multiqc_data/multiqc_sources.txt",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",
-                "pipeline_info/nf_core_cellpainting_software_mqc_versions.yml"
+                "pipeline_info/nf_core_cellpainting_software_mqc_versions.yml",
+                "plateviewer",
+                "plateviewer/plate_montages_mqc.html"
             ],
             [
                 "A01_s1--cell_outlines.png:md5,7e9daf852c256b16e14bfcaf46236bab",
@@ -132,14 +145,16 @@
                 "BR00117035_IllumER.npy:md5,75062bcc5f10eb9db2ee9e18b9fc4d40",
                 "BR00117035_IllumMito.npy:md5,d33a48d56045736f46a470f44955ff07",
                 "BR00117035_IllumRNA.npy:md5,c21cb042cfb15cc7ca939eef99d4ebd3",
-                "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
+                "2021_04_26_Batch1_BR00117035_montage_mqc.png:md5,6577f6d755e7b007ccc20b2ea279ae0e",
+                "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+                "plate_montages_mqc.html:md5,9ace299df0cf84d9530795829827669f"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T12:30:20.129752"
+        "timestamp": "2026-04-29T02:12:33.838134"
     },
     "-profile test -stub": {
         "content": [
@@ -152,6 +167,9 @@
                 },
                 "CELLPROFILER_ILLUMINATIONCORRECTION": {
                     "cellprofiler": "4.2.8"
+                },
+                "IMAGEMAGICK_MONTAGE": {
+                    "imagemagick": "7.1.2-21"
                 },
                 "Workflow": {
                     "nf-core/cellpainting": "v1.0.0dev"
@@ -204,8 +222,10 @@
                 "cellprofiler/analysis/2021_04_26_Batch1_BR00117035_B01_2/analysis/mock_overlay.png",
                 "cellprofiler/assay_development",
                 "cellprofiler/assay_development/assaydevelopment",
+                "cellprofiler/assay_development/assaydevelopment/2021_04_26_Batch1_BR00117035_A01_ObjectOverlay.png",
+                "cellprofiler/assay_development/assaydevelopment/2021_04_26_Batch1_BR00117035_A02_ObjectOverlay.png",
+                "cellprofiler/assay_development/assaydevelopment/2021_04_26_Batch1_BR00117035_B01_ObjectOverlay.png",
                 "cellprofiler/assay_development/assaydevelopment/Image.csv",
-                "cellprofiler/assay_development/assaydevelopment/mock_segmentedimage.png",
                 "cellprofiler/illumination_correction",
                 "cellprofiler/illumination_correction/illumination_corrections",
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumAGP.npy",
@@ -217,13 +237,25 @@
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumMito.npy",
                 "cellprofiler/illumination_correction/illumination_corrections/BR00117035_IllumRNA.npy",
                 "cytotable",
-                "cytotable/2021_04_26_Batch1_BR00117035.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A01_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_A02_2.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_1.parquet",
+                "cytotable/2021_04_26_Batch1_BR00117035_B01_2.parquet",
+                "imagemagick",
+                "imagemagick/montage",
+                "imagemagick/montage/full",
+                "imagemagick/montage/thumbnail",
+                "imagemagick/montage/thumbnail/2021_04_26_Batch1_BR00117035_montage_mqc.png",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_plots",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",
-                "pipeline_info/nf_core_cellpainting_software_mqc_versions.yml"
+                "pipeline_info/nf_core_cellpainting_software_mqc_versions.yml",
+                "plateviewer",
+                "plateviewer/plate_montages_mqc.html"
             ],
             [
                 "mock_overlay.png:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -232,7 +264,9 @@
                 "mock_overlay.png:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mock_overlay.png:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mock_overlay.png:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "mock_segmentedimage.png:md5,f50b84b1db4b83ba62ec1deacc69c260",
+                "2021_04_26_Batch1_BR00117035_A01_ObjectOverlay.png:md5,f50b84b1db4b83ba62ec1deacc69c260",
+                "2021_04_26_Batch1_BR00117035_A02_ObjectOverlay.png:md5,f50b84b1db4b83ba62ec1deacc69c260",
+                "2021_04_26_Batch1_BR00117035_B01_ObjectOverlay.png:md5,f50b84b1db4b83ba62ec1deacc69c260",
                 "BR00117035_IllumAGP.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "BR00117035_IllumBrightfield.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "BR00117035_IllumBrightfield_H.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -240,13 +274,15 @@
                 "BR00117035_IllumDNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "BR00117035_IllumER.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "BR00117035_IllumMito.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "BR00117035_IllumRNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "BR00117035_IllumRNA.npy:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "2021_04_26_Batch1_BR00117035_montage_mqc.png:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "plate_montages_mqc.html:md5,4bf6d7cff478bfd63ac32dd7442547cf"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T12:31:39.486475"
+        "timestamp": "2026-04-29T12:08:01.374704"
     }
 }

--- a/workflows/cellpainting.nf
+++ b/workflows/cellpainting.nf
@@ -120,7 +120,9 @@ workflow CELLPAINTING {
 
     //
     // PLATE MONTAGE
-    // Collect assay dev overlay PNGs by [batch, plate], montage into plate grid for MultiQC
+    // Collect assay dev overlay PNGs by [batch, plate], montage into plate grid for MultiQC.
+    // Each well shows one representative site (cellprofiler_assaydevelopment_site) with all
+    // channels composited into a single segmentation overlay image.
     //
 
     // Derive plate dimensions from samplesheet (max row/col per batch+plate)

--- a/workflows/cellpainting.nf
+++ b/workflows/cellpainting.nf
@@ -149,8 +149,10 @@ workflow CELLPAINTING {
         }
         .groupTuple(by: [0, 1, 2])
         .map { plate_key, batch, plate, wells_meta, pngs ->
+            // Sort wells_meta and pngs together by well name for deterministic -resume caching
+            def sorted = [wells_meta, pngs].transpose().sort { a, b -> a[0].well <=> b[0].well }
             def plate_meta = [id: plate_key, batch: batch, plate: plate]
-            [plate_key, plate_meta, wells_meta, pngs]
+            [plate_key, plate_meta, sorted.collect { it[0] }, sorted.collect { it[1] }]
         }
         .combine(ch_plate_dims, by: 0)
         .map { _key, meta, wells_meta, pngs, plate_rows, plate_cols ->

--- a/workflows/cellpainting.nf
+++ b/workflows/cellpainting.nf
@@ -8,6 +8,8 @@ include { CYTOTABLE              } from '../modules/local/cytotable'
 include { CELLPROFILER_ILLUMINATIONCORRECTION } from '../modules/local/cellprofiler/illuminationcorrection'
 include { CELLPROFILER_ANALYSIS } from '../modules/local/cellprofiler/analysis'
 include { CELLPROFILER_ASSAYDEVELOPMENT } from '../modules/local/cellprofiler/assaydevelopment'
+include { IMAGEMAGICK_MONTAGE } from '../modules/local/imagemagick/montage'
+include { PLATEVIEWER } from '../modules/local/plateviewer'
 
 include { paramsSummaryMap       } from 'plugin/nf-schema'
 include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
@@ -115,6 +117,66 @@ workflow CELLPAINTING {
     )
 
     ch_versions = ch_versions.mix(CELLPROFILER_ASSAYDEVELOPMENT.out.versions)
+
+    //
+    // PLATE MONTAGE
+    // Collect assay dev overlay PNGs by [batch, plate], montage into plate grid for MultiQC
+    //
+
+    // Derive plate dimensions from samplesheet (max row/col per batch+plate)
+    ch_enriched
+        .map { meta, _image ->
+            def plate_key = [meta.batch, meta.plate].join('_')
+            [plate_key, meta.row as int, meta.col as int]
+        }
+        .groupTuple()
+        .map { key, rows, cols -> [key, rows.max(), cols.max()] }
+        .set { ch_plate_dims }
+
+    // Collect overlay PNGs by [batch, plate], derive well row/col from well name.
+    // Each assay dev emission is one well — flatMap to one entry per PNG, then
+    // groupTuple keeps well_info (pos 3) and png (pos 4) as parallel lists.
+    CELLPROFILER_ASSAYDEVELOPMENT.out.png
+        .flatMap { meta, pngs ->
+            def plate_key = [meta.batch, meta.plate].join('_')
+            def well_row = (meta.well[0] as char) - ('A' as char) + 1
+            def well_col = (meta.well.substring(1)) as int
+            def well_info = [well: meta.well, row: well_row, col: well_col]
+            def png_list = pngs instanceof List ? pngs.flatten() : [pngs]
+            png_list.collect { png -> [plate_key, meta.batch, meta.plate, well_info, png] }
+        }
+        .groupTuple(by: [0, 1, 2])
+        .map { plate_key, batch, plate, wells_meta, pngs ->
+            def plate_meta = [id: plate_key, batch: batch, plate: plate]
+            [plate_key, plate_meta, wells_meta, pngs]
+        }
+        .combine(ch_plate_dims, by: 0)
+        .map { _key, meta, wells_meta, pngs, plate_rows, plate_cols ->
+            [meta, wells_meta, pngs, plate_rows, plate_cols]
+        }
+        .set { ch_montage_input }
+
+    IMAGEMAGICK_MONTAGE(ch_montage_input)
+
+    //
+    // PLATE VIEWER
+    // Aggregate all plate montages into an interactive HTML viewer for MultiQC
+    //
+    IMAGEMAGICK_MONTAGE.out.montage
+        .map { meta, png -> [meta.id, png] }
+        .collect()
+        .map { items ->
+            // items is a flat list: [id1, png1, id2, png2, ...]
+            def pairs = items.collate(2)
+            def ids = pairs.collect { List pair -> pair[0] }
+            def pngs = pairs.collect { List pair -> pair[1] }
+            [ids, pngs]
+        }
+        .set { ch_all_montages }
+
+    PLATEVIEWER(ch_all_montages)
+
+    ch_multiqc_files = ch_multiqc_files.mix(PLATEVIEWER.out.html)
 
     if (cellprofiler_mode == 'analysis') {
 


### PR DESCRIPTION
## Summary

Implements #5 — stitches per-well assay development overlay PNGs into plate-grid montages with an interactive plate viewer embedded in the MultiQC report. Uses ImageMagick rather than Fiji, as the issue noted the tool choice was flexible. Split into two modules: per-plate montage creation (parallelizable across plates) and cross-plate HTML viewer aggregation (sequential, waits for all plates).

### IMAGEMAGICK_MONTAGE (per plate, parallelized)

- Collects per-well overlay PNGs by [batch, plate] and arranges them in a plate-grid layout using ImageMagick montage
- Plate-style row/column headers (A-P left, 1-24 top) at 50% tile height
- Plate dimensions auto-detected from samplesheet max row/col
- Missing wells rendered as black tiles via `null:` placeholder
- Well-to-file mapping via channel metadata (no filename conventions assumed)
- Optional full-resolution lossless TIFF montage via `ext.full_res` (off by default)
- Multi-arch container (linux/amd64 + linux/arm64) built via Wave CLI
- Thumbnail montage resizes tiles during assembly to keep memory low

### PLATEVIEWER (all plates, sequential)

- Aggregates all plate montages into a self-contained HTML with a dropdown plate selector embedded in MultiQC via `_mqc.html` convention
- Scales to 100+ plates (single viewport, one image at a time)
- Collapsible help text showing output file locations
- No container needed (Python stdlib only)

### Other changes

- Assay dev stub output modified to use unique per-well filenames to avoid Nextflow `stageAs` collision when montage collects across wells
- Montage publishDir split into `thumbnail/` and `full/` subdirectories

### Tool choice notes

- ImageMagick (865 MB) chosen over Fiji (1.61 GB) since no image registration or advanced stitching is needed — just grid assembly
- A multi-arch Fiji container was also built via Wave CLI for reference: `community.wave.seqera.io/library/fiji:fiji-20250206--545cf8eeaa3ab290`

## Test plan

- [x] Module stub test (IMAGEMAGICK_MONTAGE)
- [x] 96-well plate thumbnail test with real overlay PNGs from test-datasets
- [x] 4-well full-resolution TIFF test
- [x] 24-well sparse plate test (18 of 24 wells, gaps rendered correctly)
- [x] PLATEVIEWER module test (3-plate HTML generation with dropdown verification)
- [x] PLATEVIEWER stub test
- [x] Full pipeline stub test (all modules end-to-end)
- [x] Full pipeline real data test (CellProfiler → montage → plate viewer → MultiQC)
- [x] nf-core pipelines lint: 236 passed, 0 failures
- [x] pre-commit: all passed
- [x] Verified montage appears in MultiQC report with plate selector dropdown

Closes #5