### PR TITLE
Continued Progress on #38 - Intelligent assertions for assaydevelopment module

### DIFF
--- a/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test
+++ b/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test
@@ -52,7 +52,18 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+
+                // versions.yml is fully deterministic — keep as md5 snapshot
+                { assert snapshot(process.out.versions).match() },
+
+                // PNG overlay — binary content drifts across libpng versions (macOS vs Linux CI);
+                // assert existence and non-trivial file size instead of an md5 hash
+                { assert process.out.png.size() == 1 },
+                { assert path(process.out.png[0][1]).exists() },
+                { assert path(process.out.png[0][1]).size() > 1000 },
+
+                // Image.csv is optional and not always emitted by assay development
+                { assert process.out.csv.size() == 0 },
             )
         }
     }

--- a/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap
+++ b/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap
@@ -66,11 +66,9 @@
     },
     "cellprofiler - assay development": {
         "content": [
-            {
-                "versions": [
-                    "versions.yml:md5,766f4a17b8a2ba2a5e108b7f5fee144e"
-                ]
-            }
+            [
+                "versions.yml:md5,766f4a17b8a2ba2a5e108b7f5fee144e"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.1",

--- a/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap
+++ b/modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap
@@ -67,39 +67,6 @@
     "cellprofiler - assay development": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "2021_04_26_Batch1_BR00117035_A01",
-                            "batch": "2021_04_26_Batch1",
-                            "plate": "BR00117035",
-                            "well": "A01",
-                            "site": 1
-                        },
-                        "2021_04_26_Batch1_BR00117035_A01_ObjectOverlay.png:md5,90426aae3f1d01f7e3284228aa8503b4"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    "versions.yml:md5,766f4a17b8a2ba2a5e108b7f5fee144e"
-                ],
-                "csv": [
-                    
-                ],
-                "png": [
-                    [
-                        {
-                            "id": "2021_04_26_Batch1_BR00117035_A01",
-                            "batch": "2021_04_26_Batch1",
-                            "plate": "BR00117035",
-                            "well": "A01",
-                            "site": 1
-                        },
-                        "2021_04_26_Batch1_BR00117035_A01_ObjectOverlay.png:md5,90426aae3f1d01f7e3284228aa8503b4"
-                    ]
-                ],
                 "versions": [
                     "versions.yml:md5,766f4a17b8a2ba2a5e108b7f5fee144e"
                 ]


### PR DESCRIPTION
Follows the same approach as #43, extending intelligent assertions to `modules/local/cellprofiler/assaydevelopment/tests/main.nf.test`.

### What changed

**`modules/local/cellprofiler/assaydevelopment/tests/main.nf.test`**
- Replaced `snapshot(process.out).match()` with per-output assertions inside `assertAll()`
- PNG overlay: replaced md5 snapshot with `exists()` + `size() > 1000` checks to tolerate libpng byte drift across macOS and Linux
- `Image.csv`: optional output — explicitly asserted as not emitted via `process.out.csv.size() == 0`
- `versions.yml`: retained as md5 snapshot (fully deterministic)
- Stub test left unchanged — uses a deterministic mock PNG so its md5 remains stable

**`modules/local/cellprofiler/assaydevelopment/tests/main.nf.test.snap`**
- Stripped PNG md5 hash from the real test snapshot entry; regenerated to contain `versions.yml` only

### Scope
- This covers `modules/local/cellprofiler/assaydevelopment/tests/main.nf.test`. 
- `modules/local/cellprofiler/analysis/tests/main.nf.test` is covered in #43 
- **`tests/default.nf.test` remains the last outstanding file from #38.**